### PR TITLE
change deployment target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
           SCHEME="$IOS_SCHEME"      RUN_TESTS="YES"
         - DESTINATION="platform=iOS Simulator,OS=10.3.1,name=iPhone 7 Plus"
           SCHEME="$IOS_SCHEME"      RUN_TESTS="YES"
-        - DESTINATION="platform=iOS Simulator,OS=9.3,name=iPhone 6"
-          SCHEME="$IOS_SCHEME"      RUN_TESTS="YES"
 
         - DESTINATION="platform=macOS,arch=x86_64"
           SCHEME="$MACOS_SCHEME"    RUN_TESTS="YES"
@@ -34,8 +32,6 @@ env:
         - DESTINATION="platform=tvOS Simulator,OS=11.4,name=Apple TV 4K"
           SCHEME="$TVOS_SCHEME"    RUN_TESTS="YES"
         - DESTINATION="platform=tvOS Simulator,OS=10.2,name=Apple TV 1080p"
-          SCHEME="$TVOS_SCHEME"    RUN_TESTS="YES"
-        - DESTINATION="platform=tvOS Simulator,OS=9.2,name=Apple TV 1080p"
           SCHEME="$TVOS_SCHEME"    RUN_TESTS="YES"
 
         - DESTINATION="platform=watchOS Simulator,OS=5.0,name=Apple Watch Series 4 - 44mm"

--- a/Nuke-WebP-Plugin.podspec
+++ b/Nuke-WebP-Plugin.podspec
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
   #
 
   #  When using multiple platforms
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = '10.0'
   s.osx.deployment_target  = '10.10'
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"


### PR DESCRIPTION
I had build failed at current version (v4.0.0) because Nuke v.7 minimum target at least iOS 10