### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/test-or-build.yaml
+++ b/.github/workflows/test-or-build.yaml
@@ -3,7 +3,7 @@ name: Test or Build
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test-or-build:


### PR DESCRIPTION
Actions are not triggered because the default branch has been changed from `master` to `main`.

Therefore, the Actions setting has been changed.